### PR TITLE
Add solr_mirror variable for faster solr download

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This role is currently tested and working with Solr 3.x and 4.x; 5.x is not yet 
 
 ## Role Variables
 
-Available variables are listed below, along with default values (see `vars/main.yml`):
+Available variables are listed below, along with default values (see `defaults/main.yml`):
 
     solr_workspace: /root
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Solr will be run under Jetty as the `solr_user`. Set `solr_create_user` to `fals
 
 The Apache Solr version to install.
 
+    solr_mirror: "http://archive.apache.org/dist"
+
+The Apache Project mirror where the Solr tarball will be downloaded from. In case of download timeouts it is useful to set the mirror to the [suggested site](https://www.apache.org/dyn/closer.cgi/lucene/solr/).
+
     solr_install_path: /opt/solr
 
 The path where Apache Solr will be installed.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ solr_create_user: true
 solr_user: solr
 
 solr_version: "4.10.4"
+solr_mirror: "http://archive.apache.org/dist"
 
 solr_install_path: /opt/solr
 solr_home: /var/solr

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Download Solr.
   get_url:
-    url: "http://archive.apache.org/dist/lucene/solr/{{ solr_version }}/{{ solr_filename }}.tgz"
+    url: "{{ solr_mirror }}/lucene/solr/{{ solr_version }}/{{ solr_filename }}.tgz"
     dest: "{{ solr_workspace }}/{{ solr_filename }}.tgz"
     force: no
 


### PR DESCRIPTION
Today I stuck with drupavm on the provision phase.  I got timeouts for Download Solr step. The official apache archive site was too slow. I added site_mirror variable to solve this.