### PR TITLE
Added variable "solr_init_service_name" to allow to install solr in p…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ solr_user: solr
 solr_version: "4.10.4"
 solr_mirror: "http://archive.apache.org/dist"
 
+solr_init_service_name: solr
 solr_install_path: /opt/solr
 solr_home: /var/solr
 solr_log_file_path: /var/log/solr.log

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: restart solr
-  service: name=solr state=restarted sleep=5
+  service: name="{{ solr_init_service_name }}" state=restarted sleep=5

--- a/tasks/init-script.yml
+++ b/tasks/init-script.yml
@@ -11,7 +11,7 @@
 - name: Copy solr init script into place.
   template:
     src: "solr-init-{{ ansible_os_family }}.j2"
-    dest: /etc/init.d/solr
+    dest: "/etc/init.d/{{ solr_init_service_name }}"
     mode: 0755
 
 - name: Ensure daemon is installed (Debian).
@@ -19,4 +19,4 @@
   when: ansible_os_family == "Debian"
 
 - name: Ensure solr is started and enabled on boot.
-  service: name=solr state=started enabled=yes
+  service: name="{{ solr_init_service_name }}" state=started enabled=yes

--- a/templates/solr-init-Debian.j2
+++ b/templates/solr-init-Debian.j2
@@ -14,9 +14,9 @@ START_COMMAND="java -jar $JAVA_OPTIONS start.jar"
 LOG_FILE="{{ solr_log_file_path }}"
 
 start () {
-    echo -n "Starting solr... "
+    echo -n "Starting {{ solr_init_service_name }}... "
 
-    daemon --chdir="$SOLR_DIR" --command "$START_COMMAND" --respawn --output=$LOG_FILE --name=solr
+    daemon --chdir="$SOLR_DIR" --command "$START_COMMAND" --respawn --output=$LOG_FILE --name={{ solr_init_service_name }}
 
     RETVAL=$?
     if [ $RETVAL = 0 ]
@@ -29,9 +29,9 @@ start () {
 }
 
 stop () {
-    echo -n "Stopping solr... "
+    echo -n "Stopping {{ solr_init_service_name }}... "
 
-    daemon --stop --name=solr
+    daemon --stop --name={{ solr_init_service_name }}
 
     RETVAL=$?
     if [ $RETVAL = 0 ]
@@ -45,7 +45,7 @@ stop () {
 
 restart () {
     echo -n "Restarting solr... "
-    daemon --restart --name=solr
+    daemon --restart --name={{ solr_init_service_name }}
 
     RETVAL=$?
     if [ $RETVAL = 0 ]
@@ -59,7 +59,7 @@ restart () {
 
 check_status () {
     # Report on the status of the daemon
-    daemon --running --name=solr --verbose
+    daemon --running --name={{ solr_init_service_name }} --verbose
     return $?
 }
 


### PR DESCRIPTION
…arallel in two different versions

Example:

    - {
        role: solr,
        tags: solr-4-8,
        solr_port: 8081,
        solr_version: '4.8.0',
        solr_install_path: '/opt/solr_4_8',
        solr_init_service_name: 'solr_4_8',
        solr_home: '/var/solr_4_8',
        solr_log_file_path: '/var/log/solr_4_8.log'
      }
    - {
        role: solr,
        tags: solr-4-10,
        solr_port: 8082,
        solr_version: '4.10.4',
        solr_install_path: '/opt/solr_4_10',
        solr_init_service_name: 'solr_4_10',
        solr_home: '/var/solr_4_10',
        solr_log_file_path: '/var/log/solr_4_10.log'
    }