### PR TITLE
Update template for newer debian

### DIFF
--- a/templates/solr-init-Debian.j2
+++ b/templates/solr-init-Debian.j2
@@ -8,6 +8,15 @@
 #
 # Adapted by Jeff Geerling from http://stackoverflow.com/a/8014720/100134
 
+### BEGIN INIT INFO
+# Provides:             solr
+# Required-Start:       $remote_fs $syslog
+# Required-Stop:        $remote_fs $syslog
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description:    Apache Solr search server
+### END INIT INFO
+
 SOLR_DIR="{{ solr_install_path }}/example"
 JAVA_OPTIONS="-Dsolr.solr.home={{ solr_home }} -Djetty.host={{ solr_host }} -Djetty.port={{ solr_port }} -Xms{{ solr_xms }} -Xmx{{ solr_xmx }}"
 START_COMMAND="java -jar $JAVA_OPTIONS start.jar"


### PR DESCRIPTION
If no info is provided, update-rc.d command will throw errors on Debian Jessie because on the file there is no LSB info tags:

````
TASK: [geerlingguy.solr | Ensure solr is started and enabled on boot.] ********
failed: [192.168.10.123] => {"failed": true}
msg: Error when trying to enable solr: rc=1 Synchronizing state for solr.service with sysvinit using update-rc.d...
Executing /usr/sbin/update-rc.d solr defaults
insserv: warning: script 'K01solr' missing LSB tags and overrides
insserv: warning: script 'solr' missing LSB tags and overrides
Executing /usr/sbin/update-rc.d solr enable
update-rc.d: error: solr Default-Start contains no runlevels, aborting.


FATAL: all hosts have already failed -- aborting

````