### PR TITLE
Fixes #35 by using {{ solr_service_name }}.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ solr_mirror: "https://archive.apache.org/dist"
 
 solr_service_name: solr
 solr_install_dir: /opt
-solr_install_path: /opt/solr
+solr_install_path: "/opt/{{ solr_service_name }}"
 solr_home: /var/solr
 solr_port: "8983"
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,6 +13,7 @@
     -s {{ solr_service_name }}
     -p {{ solr_port }}
     creates={{ solr_install_dir }}/{{ solr_service_name }}/bin/solr
+    creates={{ solr_install_path }}/bin/solr
   register: solr_install_script_result
 
 # Workaround for bug https://github.com/ansible/ansible-modules-core/issues/915.

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,7 +12,7 @@
     -u {{ solr_user }}
     -s {{ solr_service_name }}
     -p {{ solr_port }}
-    creates={{ solr_install_dir }}/solr/bin/solr
+    creates={{ solr_install_dir }}/{{ solr_service_name }}/bin/solr
   register: solr_install_script_result
 
 # Workaround for bug https://github.com/ansible/ansible-modules-core/issues/915.


### PR DESCRIPTION
Tested with Solr 6.1.0, untested with earlier versions.