### PR TITLE
Use {{ solr_service_name }} for the Provides variable

### DIFF
--- a/templates/solr-init-Debian-pre5.j2
+++ b/templates/solr-init-Debian-pre5.j2
@@ -9,7 +9,7 @@
 # Adapted by Jeff Geerling from http://stackoverflow.com/a/8014720/100134
 
 ### BEGIN INIT INFO
-# Provides:             solr
+# Provides:             {{ solr_service_name }}
 # Required-Start:       $remote_fs $syslog
 # Required-Stop:        $remote_fs $syslog
 # Default-Start:        2 3 4 5


### PR DESCRIPTION
Uses the solr_service_name for the Provides variable to allow multiple solr services.

Fixes: #43 