### PR TITLE
Fixes #53: systemd service usage failing with Ansible 2.2 and Solr < 5.

### DIFF
--- a/tasks/install-pre5.yml
+++ b/tasks/install-pre5.yml
@@ -68,3 +68,16 @@
 - name: Ensure daemon is installed (Debian).
   apt: name=daemon state=installed
   when: ansible_os_family == "Debian"
+
+- name: Copy solr systemd unit file into place (for systemd systems).
+  template:
+    src: solr.unit.j2
+    dest: /etc/systemd/system/solr.service
+    owner: root
+    group: root
+    mode: 0755
+  when: >
+    (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04') or
+    (ansible_distribution == 'Debian' and ansible_distribution_version|int >= 8) or
+    (ansible_distribution == 'CentOS' and ansible_distribution_version|int >= 7) or
+    (ansible_distribution == 'Fedora')

--- a/templates/solr.unit.j2
+++ b/templates/solr.unit.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Apache SOLR
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+PIDFile={{ solr_install_path }}/bin/solr-{{ solr_port }}.pid
+ExecStart={{ solr_install_path }}/bin/solr -e cloud -noprompt
+User=solr
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s QUIT $MAINPID
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Please see details in issue #53 

The unit file details were checked from https://confluence.t5.fi/display/~stefan.roos/2015/04/01/Creating+systemd+unit+(service)+for+Apache+Solr