### PR TITLE
Solr not reading cores from correct path, solr < 5

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,4 +3,3 @@
   service:
     name: "{{ solr_service_name }}"
     state: restarted
-    sleep: 5

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,4 @@
   service:
     name: "{{ solr_service_name }}"
     state: restarted
+    sleep: 5

--- a/templates/solr.unit.j2
+++ b/templates/solr.unit.j2
@@ -3,12 +3,12 @@ Description=Apache SOLR
 After=syslog.target network.target remote-fs.target nss-lookup.target
 
 [Service]
-PIDFile={{ solr_install_path }}/bin/solr-{{ solr_port }}.pid
-ExecStart={{ solr_install_path }}/bin/solr -e cloud -noprompt
+RemainAfterExit=yes
+Type=oneshot
 User=solr
-ExecReload=/bin/kill -s HUP $MAINPID
-ExecStop=/bin/kill -s QUIT $MAINPID
-PrivateTmp=true
+ExecStart=/etc/init.d/solr start
+ExecReload=/etc/init.d/solr restart
+ExecStop=/etc/init.d/solr stop
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Please see details in issue #57 and previous PR #55 

For reference, got the updated service unit file value from https://techdetails.agwego.com/2013/06/07/227/

I'm not entirely sure why this works but I guess the service unit file messed up the solr configs somehow.