### PR TITLE
Suse compatibility

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -35,3 +35,12 @@
     (ansible_os_family == 'RedHat')
     and (ansible_distribution_version.split(".")[0] == '7')
     and (solr_install_script_result.changed)
+
+- name: Run systemd daemon_reload (Suse workaround).
+  systemd:
+    name: solr
+    daemon_reload: yes
+  when: >
+    (ansible_os_family == 'Suse')
+    and (ansible_distribution_version.split(".")[0] == '12')
+    and (solr_install_script_result.changed)


### PR DESCRIPTION
When using the ansible role, on a Suse Linux Enterprise Server 12, the setup fails, during the "Ensure solr is started and enabled on boot" task.

To avoid that, a systemd daemon_reload is necessary.
I've added a task identical to the "Run systemd daemon_reload (RHEL 7 workaround)" task, to the install.yaml, but with a condition just for SLES 12.

All the other functionality of the module, is already working on Suse Linux Enterprise Server 12 (at least using Solr 5+)