### PR TITLE
Allow setting solr host ip

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,7 @@ solr_service_name: solr
 solr_install_dir: /opt
 solr_install_path: "/opt/{{ solr_service_name }}"
 solr_home: /var/solr
-solr_ip: "127.0.0.1"
+solr_host: localhost
 solr_port: "8983"
 
 solr_xms: "256M"

--- a/tasks/cores.yml
+++ b/tasks/cores.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check current list of Solr cores.
   uri:
-    url: http://{{solr_ip}}:{{ solr_port }}/solr/admin/cores
+    url: http://{{solr_host}}:{{ solr_port }}/solr/admin/cores
     return_content: yes
   register: solr_cores_current
 

--- a/tasks/cores.yml
+++ b/tasks/cores.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check current list of Solr cores.
   uri:
-    url: http://localhost:{{ solr_port }}/solr/admin/cores
+    url: http://{{solr_ip}}:{{ solr_port }}/solr/admin/cores
     return_content: yes
   register: solr_cores_current
 


### PR DESCRIPTION
Useful incase you want to restrict access by IP in the jetty engine settings`<Set name="host"><Property name="jetty.host" default="{{solr_host}}" /></Set>`