### PR TITLE
Create core configuration files as solr_user

### DIFF
--- a/tasks/cores.yml
+++ b/tasks/cores.yml
@@ -19,6 +19,8 @@
   shell: "cp -r {{ solr_install_path }}/example/files/conf/ {{ solr_home }}/data/{{ item }}/"
   when: "'{{ item }}' not in '{{ solr_cores_current.content }}'"
   with_items: "{{ solr_cores }}"
+  become: yes
+  become_user: "{{ solr_user }}"
 
 - name: Create configured cores.
   shell: "{{ solr_install_path }}/bin/solr create -c {{ item }}"


### PR DESCRIPTION
When configuring/ creating cores, the sample configuration set is not copied as the `solr_user` which results in errors later on, i.e. once the Solr instance attempts to manage the schema of the created core.