### PR TITLE
Revert "Allow setting solr host ip"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,6 @@ solr_service_name: solr
 solr_install_dir: /opt
 solr_install_path: "/opt/{{ solr_service_name }}"
 solr_home: /var/solr
-solr_host: localhost
 solr_port: "8983"
 
 solr_xms: "256M"

--- a/tasks/cores.yml
+++ b/tasks/cores.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check current list of Solr cores.
   uri:
-    url: http://{{solr_host}}:{{ solr_port }}/solr/admin/cores
+    url: http://localhost:{{ solr_port }}/solr/admin/cores
     return_content: yes
   register: solr_cores_current
 


### PR DESCRIPTION
Reverts geerlingguy/ansible-role-solr#63

Oops, just realized I still used `solr_host` for Solr < 5.0.0.

We'll have to figure out a different way. Maybe `solr_connect_host`.