### PR TITLE
Fix solr_config_file with different service_name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ solr_remove_cruft: false
 solr_service_name: solr
 solr_install_dir: /opt
 solr_install_path: "/opt/{{ solr_service_name }}"
-solr_home: /var/solr
+solr_home: "/var/{{ solr_service_name }}"
 solr_connect_host: localhost
 solr_port: "8983"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,7 @@ solr_timezone: "UTC"
 solr_cores:
   - collection1
 
-solr_config_file: /etc/default/solr.in.sh
+solr_config_file: /etc/default/{{ solr_service_name }}.in.sh
 
 # Used only for Solr < 5.
 solr_log_file_path: /var/log/solr.log


### PR DESCRIPTION
The solr installer installs the `config_file` in a file named after the `service_name`. So we need to use that instead of hardcoding it to "solr.in.sh". Else you end up with errors:

```
solr_service_name: solr-live
```
Results in:
```
TASK [geerlingguy.solr : Apply Solr configuration changes.] ********************
failed: [web59] (item={u'regexp': u'^.?SOLR_JAVA_MEM=', u'line': u'SOLR_JAVA_MEM="-Xms256M -Xmx512M"'}) => {
    "failed": true, 
    "item": {
        "line": "SOLR_JAVA_MEM=\"-Xms256M -Xmx512M\"", 
        "regexp": "^.?SOLR_JAVA_MEM="
    }, 
    "rc": 257
}

MSG:

Destination /etc/default/solr.in.sh does not exist !

failed: [web59] (item={u'regexp': u'^SOLR_PORT=', u'line': u'SOLR_PORT="8983"'}) => {
    "failed": true, 
    "item": {
        "line": "SOLR_PORT=\"8983\"", 
        "regexp": "^SOLR_PORT="
    }, 
    "rc": 257
}

MSG:

Destination /etc/default/solr.in.sh does not exist !

failed: [web59] (item={u'regexp': u'^.?SOLR_TIMEZONE=', u'line': u'SOLR_TIMEZONE="UTC"'}) => {
    "failed": true, 
    "item": {
        "line": "SOLR_TIMEZONE=\"UTC\"", 
        "regexp": "^.?SOLR_TIMEZONE="
    }, 
    "rc": 257
}

MSG:

Destination /etc/default/solr.in.sh does not exist !
```
