### PR TITLE
Allow disabling restart handler

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,9 @@ solr_cores:
 
 solr_config_file: /etc/default/solr.in.sh
 
+# Enable restart solr handler
+solr_restart_handler_enabled: true
+
 # Used only for Solr < 5.
 solr_log_file_path: /var/log/solr.log
 solr_host: "0.0.0.0"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,4 @@
     name: "{{ solr_service_name }}"
     state: restarted
     sleep: 5
+  when: solr_restart_handler_enabled


### PR DESCRIPTION
On AWS, provisioning EC2 to pack it as AMI then terminating the instance, the restart handler fails which marks the playbook as failed. This PR should allow disabling it via solr_restart_handler_enabled var.