### PR TITLE
Fixed install issue on CentOS 7

### DIFF
--- a/tasks/install-pre5.yml
+++ b/tasks/install-pre5.yml
@@ -79,5 +79,5 @@
   when: >
     (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04') or
     (ansible_distribution == 'Debian' and ansible_distribution_version|int >= 8) or
-    (ansible_distribution == 'CentOS' and ansible_distribution_version|int >= 7) or
+    (ansible_distribution == 'CentOS' and ansible_distribution_major_version >= 7) or
     (ansible_distribution == 'Fedora')


### PR DESCRIPTION
This change allows successful installation in a CentOS 7.3 box. The distribution version on CentOS 7 includes multiple decimal points, resulting in the `|int` casting the value to `0` instead of `7` as intended.

Example distribution info on CentOS 7.3:
```
vagrant@dev-web70:02:03 PM:~$ ansible -ilocalhost, all --connection local -m setup -a 'filter=ansible_distribution*'
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_distribution": "CentOS", 
        "ansible_distribution_major_version": "7", 
        "ansible_distribution_release": "Core", 
        "ansible_distribution_version": "7.3.1611"
    }, 
    "changed": false
}
```

Changing to use the `ansible_distribution_major_version` var successfully resolved the issue for me. Prior to this fix the systemd call would issue a `Service is in unknown state` error to ansible when attempting to start Solr.