### PR TITLE
Checksum verification + configurable package location + misc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.retry
 tests/test.sh
+/.idea
+/*.iml

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Memory settings for the JVM. These should be set as high as you can allow for be
 Default timezone of JVM running solr. You can override this if needed when using dataimport and delta imports (ex: comparing against a MySQL external data source). Read through Apache Solr's [Working with Dates](https://cwiki.apache.org/confluence/display/solr/Working+with+Dates) documentation for more background.
 
     solr_cores:
-      - collection1
+      - { name: collection1, confdir: sample_techproducts_configs }
 
-A list of cores / collections which should exist on the server. Each one will be created (if it doesn't exist already) using the default example configuration that ships with Solr. Note that this variable only applies when using Solr 5+.
+A list of cores / collections which should exist on the server. Each one will be created (if it doesn't exist already) using the example configuration provided in the `confdir` parameter. Note that this variable only applies when using Solr 5+.
 
     solr_connect_host: localhost
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ solr_user: solr
 
 solr_version: "6.6.0"
 solr_mirror: "https://archive.apache.org/dist"
+solr_package: "{{ solr_mirror }}/lucene/solr/{{ solr_version }}/{{ solr_filename }}.tgz"
 solr_remove_cruft: false
 
 solr_service_manage: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,4 +4,4 @@
     name: "{{ solr_service_name }}"
     state: restarted
     sleep: 5
-  when: solr_restart_handler_enabled
+  when: solr_restart_handler_enabled|bool

--- a/tasks/cores.yml
+++ b/tasks/cores.yml
@@ -7,24 +7,24 @@
 
 - name: Ensure Solr conf directories exist.
   file:
-    path: "{{ solr_home }}/data/{{ item }}/conf"
+    path: "{{ solr_home }}/data/{{ item.name }}/conf"
     state: directory
     owner: "{{ solr_user }}"
     group: "{{ solr_user }}"
     recurse: yes
-  when: "item not in solr_cores_current.content"
+  when: "item.name not in solr_cores_current.content"
   with_items: "{{ solr_cores }}"
 
 - name: Ensure core configuration directories exist.
-  shell: "cp -r {{ solr_install_path }}/example/files/conf/ {{ solr_home }}/data/{{ item }}/"
-  when: "item not in solr_cores_current.content"
+  shell: "cp -r {{ solr_install_path }}/example/files/conf/ {{ solr_home }}/data/{{ item.name }}/"
+  when: "item.name not in solr_cores_current.content"
   with_items: "{{ solr_cores }}"
   become: yes
   become_user: "{{ solr_user }}"
 
 - name: Create configured cores.
-  shell: "{{ solr_install_path }}/bin/solr create -c {{ item }}"
-  when: "item not in solr_cores_current.content"
+  shell: "{{ solr_install_path }}/bin/solr create -c {{ item.name }} -d {{ item.confdir }}"
+  when: "item.name not in solr_cores_current.content"
   with_items: "{{ solr_cores }}"
   become: yes
   become_user: "{{ solr_user }}"

--- a/tasks/cores.yml
+++ b/tasks/cores.yml
@@ -16,15 +16,11 @@
   with_items: "{{ solr_cores }}"
 
 - name: Ensure core configuration directories exist.
-  shell: "cp -r {{ solr_install_path }}/example/files/conf/ {{ solr_home }}/data/{{ item.name }}/"
+  shell: "sudo -u {{ solr_user }} cp -r {{ solr_install_path }}/example/files/conf/ {{ solr_home }}/data/{{ item.name }}/"
   when: "item.name not in solr_cores_current.content"
   with_items: "{{ solr_cores }}"
-  become: yes
-  become_user: "{{ solr_user }}"
 
 - name: Create configured cores.
-  shell: "{{ solr_install_path }}/bin/solr create -c {{ item.name }} -d {{ item.confdir }}"
+  shell: "sudo -u {{ solr_user }} {{ solr_install_path }}/bin/solr create -c {{ item.name }} -d {{ item.confdir }}"
   when: "item.name not in solr_cores_current.content"
   with_items: "{{ solr_cores }}"
-  become: yes
-  become_user: "{{ solr_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,11 +17,22 @@
     path: "{{ solr_install_path }}"
   register: solr_install_path_status
 
+- name: Download SHA-1 checksum from the Apache site
+  uri:
+    url: "https://archive.apache.org/dist/lucene/solr/{{ solr_version }}/{{ solr_filename }}.tgz.sha1"
+    return_content: yes
+  register: sha1_file
+
+- name: Get checksum
+  set_fact:
+    sha1_checksum: "{{ (sha1_file.content|string).split(' ')[0] }}"
+
 - name: Download Solr.
   get_url:
-    url: "{{ solr_mirror }}/lucene/solr/{{ solr_version }}/{{ solr_filename }}.tgz"
+    url: "{{ solr_package }}"
     dest: "{{ solr_workspace }}/{{ solr_filename }}.tgz"
     force: no
+    checksum: "sha1:{{ sha1_checksum }}"
   when: solr_install_path_status.stat.isdir is not defined
   register: solr_download_status
 
@@ -34,11 +45,11 @@
 
 # Install Solr < 5.
 - include: install-pre5.yml
-  when: "solr_version.split('.')[0] < '5'"
+  when: "solr_version.split('.')[0] < '5' and solr_install_path_status.stat.isdir is not defined"
 
 # Install Solr 5+.
 - include: install.yml
-  when: "solr_version.split('.')[0] >= '5'"
+  when: "solr_version.split('.')[0] >= '5' and solr_install_path_status.stat.isdir is not defined"
 
 - name: Ensure solr is started and enabled on boot if configured.
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - import_tasks: user.yml
-  when: solr_create_user
+  when: solr_create_user|bool
 
 - name: Set solr_filename for Solr 4+.
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: user.yml
+- import_tasks: user.yml
   when: solr_create_user
 
 - name: Set solr_filename for Solr 4+.
@@ -44,11 +44,11 @@
   when: solr_download_status.changed
 
 # Install Solr < 5.
-- include: install-pre5.yml
+- import_tasks: install-pre5.yml
   when: "solr_version.split('.')[0] < '5' and solr_install_path_status.stat.isdir is not defined"
 
 # Install Solr 5+.
-- include: install.yml
+- import_tasks: install.yml
   when: "solr_version.split('.')[0] >= '5' and solr_install_path_status.stat.isdir is not defined"
 
 - name: Ensure solr is started and enabled on boot if configured.
@@ -59,12 +59,11 @@
   when: solr_service_manage
 
 # Configure solr.
-- include: configure.yml
+- import_tasks: configure.yml
   when: "solr_version.split('.')[0] >= '5'"
 
 # Create cores, if any are configured.
-- include: cores.yml
+- import_tasks: cores.yml
   when: "solr_cores and solr_version.split('.')[0] >= '5'"
 
-- include: trim-fat.yml
-  static: no
+- include_tasks: trim-fat.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
     name: "{{ solr_service_name }}"
     state: "{{ solr_service_state }}"
     enabled: yes
-  when: solr_service_manage
+  when: solr_service_manage|bool
 
 # Configure solr.
 - import_tasks: configure.yml

--- a/tasks/trim-fat.yml
+++ b/tasks/trim-fat.yml
@@ -11,12 +11,12 @@
   file:
     path: "{{ solr_install_path }}/docs"
     state: absent
-  when: solr_remove_cruft
+  when: solr_remove_cruft|bool
 
 - name: Remove example dir, if not needed.
   file:
     path: "{{ solr_install_path }}/example"
     state: absent
   when:
-    - solr_remove_cruft
+    - solr_remove_cruft|bool
     - solr_version.split('.')[0] >= '5'


### PR DESCRIPTION
This pull request proposes some improvements:

* Verifying the checksum of the solr tgz downloaded from a mirror.
* Git-ignore IntelliJ housekeeping files.
* Ability to specify the template to base the core you want to create on.
* `solr_package` variable to point to a location for the solr tgz, different from a mirror.

I realize that it is a bit too much for one PR, but it could serve as a basis for improvements. 