### PR TITLE
Use ansible_service_mgr to detect systemd.

### DIFF
--- a/tasks/install-pre5.yml
+++ b/tasks/install-pre5.yml
@@ -64,10 +64,11 @@
     src: "solr-init-{{ ansible_os_family }}-pre5.j2"
     dest: "/etc/init.d/{{ solr_service_name }}"
     mode: 0755
+  when: "ansible_service_mgr != 'systemd'"
 
 - name: Ensure daemon is installed (Debian).
   apt: name=daemon state=installed
-  when: ansible_os_family == "Debian"
+  when: "ansible_service_mgr != 'systemd' and ansible_os_family == 'Debian'"
 
 - name: Copy solr systemd unit file into place (for systemd systems).
   template:
@@ -76,8 +77,4 @@
     owner: root
     group: root
     mode: 0755
-  when: >
-    (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04') or
-    (ansible_distribution == 'Debian' and ansible_distribution_version|int >= 8) or
-    (ansible_distribution == 'CentOS' and ansible_distribution_major_version|int >= 7) or
-    (ansible_distribution == 'Fedora')
+  when: "ansible_service_mgr == 'systemd'"


### PR DESCRIPTION
Ansible provides a cleaner way to detect systemd, instead of explicitly checking distro versions.