### PR TITLE
Improve support for Solr 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ env:
     playbook: test-solr-4.yml
   - distro: ubuntu1404
     playbook: test-solr-3.yml
+  - distro: ubuntu1404
+    playbook: test-solr-1.yml
 
 script:
   # Configure test script so we can run extra tests after playbook is run.

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ env:
     playbook: test-solr-3.yml
   - distro: ubuntu1404
     playbook: test-solr-1.yml
+  - distro: centos6
+    playbook: test-solr-1.yml
 
 script:
   # Configure test script so we can run extra tests after playbook is run.

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
 
   # Make sure Solr is running.
   - >
-    sudo docker exec ${container_id} ps -ax | grep -q 'solr'
+    sudo docker exec ${container_id} ps ax | grep -q 'solr'
     && (echo 'solr is running: pass' && exit 0)
     || (echo 'solr is running: fail' && exit 1)
 

--- a/tasks/install-pre5.yml
+++ b/tasks/install-pre5.yml
@@ -17,9 +17,13 @@
   when: not solr_war_file.stat.exists
 
 # Set up solr_home.
-- name: Check if solr_home is already set up.
+- name: Check if solr_home is already set up (Solr 3.x+).
   stat: "path={{ solr_home }}/solr.xml"
   register: solr_example
+
+- name: Check if solr_home is already set up (Solr 1.x).
+  stat: "path={{ solr_home }}/conf/solrconfig.xml"
+  register: solr1_example
 
 - name: Ensure solr_home directory exists.
   file:
@@ -28,11 +32,11 @@
     owner: "{{ solr_user }}"
     group: "{{ solr_user }}"
     mode: 0755
-  when: not solr_example.stat.exists
+  when: not (solr_example.stat.exists or solr1_example.stat.exists)
 
 - name: Copy Solr example into solr_home.
   shell: "cp -r {{ solr_install_path }}/example/solr/* {{ solr_home }}"
-  when: not solr_example.stat.exists
+  when: not (solr_example.stat.exists or solr1_example.stat.exists)
 
 - name: Fix the example solrconfig.xml file.
   replace:
@@ -47,7 +51,7 @@
     owner: "{{ solr_user }}"
     group: "{{ solr_user }}"
     recurse: yes
-  when: not solr_example.stat.exists
+  when: not (solr_example.stat.exists or solr1_example.stat.exists)
 
 # Set up Solr init script.
 - name: Ensure log file is created and has proper permissions.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,10 +7,10 @@
     solr_filename: "solr-{{ solr_version }}"
   when: "solr_version.split('.')[0] >= '4'"
 
-- name: Set solr_filename for Solr 3.x.
+- name: Set solr_filename for Solr 1.x-3.x.
   set_fact:
     solr_filename: "apache-solr-{{ solr_version }}"
-  when: "solr_version.split('.')[0] == '3'"
+  when: "solr_version.split('.')[0] <= '3'"
 
 - name: Check if Solr has been installed already.
   stat:

--- a/tests/test-solr-1.yml
+++ b/tests/test-solr-1.yml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+
+  vars:
+    solr_version: "1.4.1"
+
+  roles:
+    - geerlingguy.java
+    - role_under_test


### PR DESCRIPTION
Unfortunately I still have to support a CentOS 6 instance with an ancient Solr 1.x install. This PR fixes a couple of minor bugs in the role's support for Solr 1.x and adds tests for both CentOS and Ubuntu.