### PR TITLE
Fix bugs in pre-5 systemd service unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Whether to remove unneccessary documentation and examples from the solr director
     solr_service_name: solr
     solr_service_state: started
 
-By default, this role will manage the `solr` service, ensuring it is enabled at system boot and is running. You can ensure Solr is stopped by setting `solr_service_state: stopped`, or you can disable this role's management of the `solr` service entirely by setting `solr_service_manage: true`. You may also want to set `solr_restart_handler_enabled: false` (documented later) in this case.
+By default, this role will manage the `solr` service, ensuring it is enabled at system boot and is running. You can ensure Solr is stopped by setting `solr_service_state: stopped`, or you can disable this role's management of the `solr` service entirely by setting `solr_service_manage: false`. You may also want to set `solr_restart_handler_enabled: false` (documented later) in this case.
 
     solr_install_dir: /opt
     solr_install_path: /opt/solr

--- a/tasks/install-pre5.yml
+++ b/tasks/install-pre5.yml
@@ -76,7 +76,7 @@
 - name: Copy solr systemd unit file into place (for systemd systems).
   template:
     src: solr-pre5.unit.j2
-    dest: /etc/systemd/system/solr.service
+    dest: /etc/systemd/system/{{ solr_service_name }}.service
     owner: root
     group: root
     mode: 0755

--- a/templates/solr-pre5.unit.j2
+++ b/templates/solr-pre5.unit.j2
@@ -7,7 +7,7 @@ Type=simple
 WorkingDirectory={{ solr_install_path }}/example
 ExecStart=/usr/bin/java -jar -Dsolr.solr.home={{ solr_home }} -Djetty.host={{ solr_host }} -Djetty.port={{ solr_port }} -Xms{{ solr_xms }} -Xmx{{ solr_xmx }} start.jar
 Restart=on-failure
-User=solr
+User={{ solr_user }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The pre-5 systemd service unit does not take into account either the `solr_service_name` or the `solr_user` variables, this PR fixes that.

It also fixes a tiny mistake in the README where the `solr_service_manage` boolean is accidentally inverted.