### PR TITLE
enable log4j

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,14 @@ solr_cores:
 
 solr_config_file: /etc/default/{{ solr_service_name }}.in.sh
 
+log4j_logger: 'WARN, file'
+log4j_appender_file: 'org.apache.log4j.RollingFileAppender'
+log4j_maxfilesize: 500MB
+log4j_maxbackupindex: 7
+log4j_logpath: '/var/log/solr.log'
+log4j_layout: 'org.apache.log4j.PatternLayout'
+log4j_layout_conversionpattern: '%-5p - %d{yyyy-MM-dd HH:mm:ss.SSS}; %C; %m\n'
+
 # Enable restart solr handler
 solr_restart_handler_enabled: true
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,3 +56,12 @@
   when: "solr_cores and solr_version.split('.')[0] >= '5'"
 
 - include_tasks: trim-fat.yml
+
+# Create log4j.properties
+- name: create log4j.properties
+  template:
+    src: log4j.properties
+    dest: '{{ solr_home }}/log4j.properties'
+    mode: 0644
+    owner: '{{ solr_user }}'
+    group: '{{ solr_user }}'

--- a/templates/log4j.properties
+++ b/templates/log4j.properties
@@ -1,0 +1,21 @@
+#  Logging level
+
+log4j.rootLogger={{ log4j_logger }}
+
+
+#- size rotation with log cleanup.
+
+log4j.appender.file={{ log4j_appender_file }}
+
+log4j.appender.file.MaxFileSize={{ log4j_maxfilesize }}
+
+log4j.appender.file.MaxBackupIndex={{ log4j_maxbackupindex }}
+
+
+#- File to log to and log format
+
+log4j.appender.file.File={{ log4j_logpath }}
+
+log4j.appender.file.layout={{ log4j_layout }}
+
+log4j.appender.file.layout.ConversionPattern={{ log4j_layout_conversionpattern }}

--- a/templates/solr-init-Debian-pre5.j2
+++ b/templates/solr-init-Debian-pre5.j2
@@ -18,7 +18,7 @@
 ### END INIT INFO
 
 SOLR_DIR="{{ solr_install_path }}/example"
-JAVA_OPTIONS="-Dsolr.solr.home={{ solr_home }} -Djetty.host={{ solr_host }} -Djetty.port={{ solr_port }} -Xms{{ solr_xms }} -Xmx{{ solr_xmx }}"
+JAVA_OPTIONS="-Dsolr.solr.home={{ solr_home }} -Djetty.host={{ solr_host }} -Dlog4j.configuration=file:{{ solr_home }}/log4j.properties -Djetty.port={{ solr_port }} -Xms{{ solr_xms }} -Xmx{{ solr_xmx }}"
 START_COMMAND="java -jar $JAVA_OPTIONS start.jar"
 LOG_FILE="{{ solr_log_file_path }}"
 

--- a/templates/solr-init-RedHat-pre5.j2
+++ b/templates/solr-init-RedHat-pre5.j2
@@ -9,7 +9,7 @@
 . /etc/rc.d/init.d/functions
 
 SOLR_DIR="{{ solr_install_path }}/example"
-JAVA_OPTIONS="-Dsolr.solr.home={{ solr_home }} -Djetty.host={{ solr_host }} -Djetty.port={{ solr_port }} -Xms{{ solr_xms }} -Xmx{{ solr_xmx }} -DSTOP.PORT=8079 -DSTOP.KEY=secret"
+JAVA_OPTIONS="-Dsolr.solr.home={{ solr_home }} -Djetty.host={{ solr_host }} -Dlog4j.configuration=file:{{ solr_home }}/log4j.properties -Djetty.port={{ solr_port }} -Xms{{ solr_xms }} -Xmx{{ solr_xmx }} -DSTOP.PORT=8079 -DSTOP.KEY=secret"
 START_COMMAND="java -jar $JAVA_OPTIONS start.jar"
 STOP_COMMAND="java -jar $JAVA_OPTIONS $SOLR_DIR/start.jar --stop"
 LOG_FILE="{{ solr_log_file_path }}"


### PR DESCRIPTION
Solr log can fill up quickly on a busy Solr node. This change enable log4j which give us more control over Solr log including log rotation ( which is more ideal solution compare to Logrotate ). 