### PR TITLE
Prevent Solr autostart with the -n install flag

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,6 +16,7 @@
     -u {{ solr_user }}
     -s {{ solr_service_name }}
     -p {{ solr_port }}
+    -n
     creates={{ solr_install_path }}/bin/solr
   register: solr_install_script_result
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,7 +16,7 @@
     -u {{ solr_user }}
     -s {{ solr_service_name }}
     -p {{ solr_port }}
-    -n
+    {{ (solr_version is version('6.3.0', '>='))|ternary('-n','') }}
     creates={{ solr_install_path }}/bin/solr
   register: solr_install_script_result
 


### PR DESCRIPTION
By default, the Solr installation will also start the service after installation. This came as a surprise to me and not desired when I've set `solr_service_state: stopped`.

The installer has the `-n` flag to disable this behavior. However, this option is only available from version 6.3.0 onwards ( https://github.com/apache/lucene-solr/commit/b894ab292d3f319d03f375fc04376fbee6760b3f ). As such this PR is more of a **WIP** than anything else.

I specifically need this behavior as I'm dropping the SysV startup script to a hand-rolled systemd service file, as the bundled SysV service doesn't work out of the box on a SELinux enabled system. See my email on the dev mailing list for more info http://archive.vn/ld10Q

There are three important aspects to which I'll defer the decision.
 - [ ] this flag would be enabled based on a mix of version check and solr_service_state
 - [ ] the core initialization assumes a running Solr instance, in order to check existing cores.
   - [ ] A conditional can be used there as well, that would warn core initialization cannot be done with a running instance
   - [ ] Switch to filesystem checks for existing cores

The bigger issue overall is that the Solr service just doesn't work on SELinux system right now, without custom type enforcement policies.
 - [ ] Should I provide the template systemd service file I use so that this role can swap to it instead of the SysV script?