### PR TITLE
Add -f in install script to force reinstall

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,6 +18,7 @@
     -s {{ solr_service_name }}
     -p {{ solr_port }}
     {{ (solr_version is version('6.3.0', '>=')) | ternary('-n','') }}
+    {{ (solr_version is version('5.4.0', '>=')) | ternary('-f','') }}
     creates={{ solr_install_path }}/bin/solr
   register: solr_install_script_result
 


### PR DESCRIPTION
The -f switch is available since version 5.4.0 so copycatting the line above for version check.

See https://github.com/apache/lucene-solr/blob/releases/lucene-solr%2F5.4.0/solr/bin/install_solr_service.sh vs
https://github.com/apache/lucene-solr/blob/releases/lucene-solr%2F5.3.0/solr/bin/install_solr_service.sh