### PR TITLE
set correct solr_filename for Solr 4.0.0

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,9 @@
 - name: Set solr_filename for Solr 4+.
   set_fact:
     solr_filename: "solr-{{ solr_version }}"
-  when: "solr_version.split('.')[0] >= '4'"
+  when: 
+    - "solr_version.split('.')[0] >= '4'"
+    - "solr_version.split('.')[1] > '0'"
 
 - name: Set solr_filename for Solr 3.x.
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,8 +12,8 @@
 - name: Set solr_filename for Solr 3.x.
   set_fact:
     solr_filename: "apache-solr-{{ solr_version }}"
-  when: "solr_version.split('.')[0] == '3'"
-
+  when: ("solr_version.split('.')[0] == '3'") or ("solr_version == '4.0.0'")
+    
 - name: Check if Solr has been installed already.
   stat:
     path: "{{ solr_install_path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Set solr_filename for Solr 4+.
   set_fact:
     solr_filename: "solr-{{ solr_version }}"
-  when: 
+  when:
     - "solr_version.split('.')[0] >= '4'"
     - "solr_version.split('.')[1] > '0'"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
   set_fact:
     solr_filename: "apache-solr-{{ solr_version }}"
   when: ("solr_version.split('.')[0] == '3'") or ("solr_version == '4.0.0'")
-    
+
 - name: Check if Solr has been installed already.
   stat:
     path: "{{ solr_install_path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
     - "solr_version.split('.')[0] >= '4'"
     - "solr_version.split('.')[1] > '0'"
 
-- name: Set solr_filename for Solr 3.x.
+- name: Set solr_filename for Solr 3.x or 4.0.0.
   set_fact:
     solr_filename: "apache-solr-{{ solr_version }}"
   when: ("solr_version.split('.')[0] == '3'") or ("solr_version == '4.0.0'")


### PR DESCRIPTION
While trying to install Solr 4.0.0 I notice the role was trying to download `solr-4.0.0.tgz` instead of the correct one `apache-solr-4.0.0.tgz` here https://archive.apache.org/dist/lucene/solr/4.0.0/. These edits should fix this.

Thank you for writing this very useful Ansible role.


