### PR TITLE
Select project archive according to Solr version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,9 +17,19 @@
     path: "{{ solr_install_path }}"
   register: solr_install_path_status
 
+- name: Set solr_mirror for Solr < 9.
+  set_fact:
+    solr_mirror: "{{ solr_mirror }}/lucene"
+  when: solr_version.split('.')[0]|int < 9
+
+- name: Set solr_mirror for Solr 9+.
+  set_fact:
+    solr_mirror: "{{ solr_mirror }}/solr"
+  when: solr_version.split('.')[0]|int >= 9
+
 - name: Download Solr.
   get_url:
-    url: "{{ solr_mirror }}/lucene/solr/{{ solr_version }}/{{ solr_filename }}.tgz"
+    url: "{{ solr_mirror }}/solr/{{ solr_version }}/{{ solr_filename }}.tgz"
     dest: "{{ solr_workspace }}/{{ solr_filename }}.tgz"
     force: false
   when: solr_install_path_status.stat.isdir is not defined


### PR DESCRIPTION
With the [release of Solr 9.0.0](https://solr.apache.org/news.html#apache-solrtm-900-available), archives for Solr are available in two different projects:

- Solr 8.x and earlier are hosted in the Lucene archives
- Solr 9.x and up are hosted in the Solr archives

With this PR, the role will chose the correct project (folder in the mirror) depending on the selected Solr version.