### PR TITLE
Better filtering for Solr cores

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The hostname or IP address to which Solr will bind. Defaults to `0.0.0.0` which 
 
 ## Dependencies
 
-None.
+jmespath libryary on Ansible controller.
 
 ## Example Playbook
 

--- a/tasks/cores.yml
+++ b/tasks/cores.yml
@@ -14,19 +14,19 @@
     group: "{{ solr_group }}"
     recurse: true
     mode: 0755
-  when: "item not in solr_cores_current.content"
+  when: "item not in solr_cores_current.json | community.general.json_query('status.*.name')"
   with_items: "{{ solr_cores }}"
 
 - name: Ensure core configuration directories exist.
   command: "cp -r {{ solr_install_path }}/example/files/conf/ {{ solr_home }}/data/{{ item }}/"
-  when: "item not in solr_cores_current.content"
+  when: "item not in solr_cores_current.json | community.general.json_query('status.*.name')"
   with_items: "{{ solr_cores }}"
   become: true
   become_user: "{{ solr_user }}"
 
 - name: Create configured cores.
   command: "{{ solr_install_path }}/bin/solr create -c {{ item }} -p {{ solr_port }}"
-  when: "item not in solr_cores_current.content"
+  when: "item not in solr_cores_current.json | community.general.json_query('status.*.name')"
   with_items: "{{ solr_cores }}"
   become: true
   become_user: "{{ solr_user }}"


### PR DESCRIPTION
Hey,

to allow simple Solr core names like "it", "at" etc. This would be skipped because this strings are inside the HTTP API answer. I have modified the filter criteria for core creation to the name of the cores, not the whole HTTP API content.

This add the jmespath dependency but I think its worth it.

Please check and merge.

BR,

AnonJo