### PR TITLE
Adjust path for default cores in Solr 9

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,8 @@ solr_opts: "$SOLR_OPTS -Dlog4j2.formatMsgNoLookups=true"
 solr_cores:
   - collection1
 
+solr_default_core_path: "{% if solr_version.split('.')[0] < '9' %}{{ solr_install_path }}/example/files/conf/{% else %}{{ solr_install_path }}/server/solr/configsets/_default/conf/{% endif %}"
+
 solr_config_file: /etc/default/{{ solr_service_name }}.in.sh
 
 # Enable restart solr handler

--- a/tasks/cores.yml
+++ b/tasks/cores.yml
@@ -18,7 +18,7 @@
   with_items: "{{ solr_cores }}"
 
 - name: Ensure core configuration directories exist.
-  command: "cp -r {{ solr_install_path }}/example/files/conf/ {{ solr_home }}/data/{{ item }}/"
+  command: "cp -r {{ solr_default_core_path }} {{ solr_home }}/data/{{ item }}/"
   when: "item not in solr_cores_current.content"
   with_items: "{{ solr_cores }}"
   become: true


### PR DESCRIPTION
When this Ansible role is asked to create some cores, it copies Solr's default core configuration to the new core's target directory. Traditionally the source files for the default core definitions were to be found at `./example/files/conf/` in Solr's binary distribution files. Starting from v9.0.0 the new location for the default core definitions is `./server/solr/configsets/_default/conf/`.

So to enable this Ansible role to work for Solr 9+, here's a modest proposal to differentiate between the versions by setting a variable named `solr_default_core_path` conditionally.