### PR TITLE
replaced ansible_distribution_version.split with distribution_major_v…

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,7 +16,7 @@
   when:
     - ansible_service_mgr == 'systemd'
     - ansible_os_family == 'RedHat'
-    - ansible_distribution_version.split(".")[0] >= '9'
+    - distribution_major_version >= '9'
 
 - name: Ensure service wrapper is installed for RHEL 7 & 8.
   package:
@@ -27,7 +27,7 @@
   when:
     - ansible_service_mgr == 'systemd'
     - ansible_os_family == 'RedHat'
-    - ansible_distribution_version.split(".")[0] <= '8'
+    - distribution_major_version <= '8'
 
 - name: Ensure service wrapper is installed for Debian-based distributions.
   package:
@@ -57,7 +57,7 @@
   command: service {{ solr_service_name }} stop
   when:
     - ansible_os_family == 'RedHat'
-    - ansible_distribution_version.split(".")[0] >= '7'
+    - distribution_major_version >= '7'
     - solr_install_script_result.changed
   failed_when: false
   tags: ['skip_ansible_lint']
@@ -68,6 +68,6 @@
     daemon_reload: true
   when:
     - ansible_os_family == 'RedHat'
-    - ansible_distribution_version.split(".")[0] >= '7'
+    - distribution_major_version >= '7'
     - solr_install_script_result.changed
   tags: ['skip_ansible_lint']


### PR DESCRIPTION
`ansible-core==2.15.4 ` and `molecule==6.0.2` as well as `ansible-core==2.13.13`/`molecule==4.0.4` were not able to parse `ansible_distribution_version.split(".")[0]` correctly when using the docker-rockylinux9-ansible docker image. I noticed that using distribution_major_version works with the mentioned Rocky 9 image as well with docker-centos7-ansible.