### PR TITLE
feat: solr listen on custom network interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ The path where local Solr data (search collections and configuration) will be st
 
     solr_port: "8983"
 
-The port on which Solr will run.
+The port on which Solr will run. 
+
+    solr_jetty_host: "127.0.0.1" 
+
+The network interface on which Solr will listen. You can define a value different than 127.0.0.1 just for solr version 9.3.0 and higher.
 
     solr_xms: "256M"
     solr_xmx: "512M"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ solr_install_path: "/opt/{{ solr_service_name }}"
 solr_home: "/var/{{ solr_service_name }}"
 solr_connect_host: localhost
 solr_port: "8983"
+solr_jetty_host: "127.0.0.1"
 
 solr_xms: "256M"
 solr_xmx: "512M"

--- a/tasks/checks.yml
+++ b/tasks/checks.yml
@@ -1,4 +1,6 @@
+---
 - name: Check for incompatible solr_jetty_host
   fail:
     msg: 'You can set solr_jetty_host other than 127.0.0.1 only when the Solr version is 9.3.0 or higher'
   when: solr_jetty_host != '127.0.0.1' and solr_version is version('9.3.0' ,'<')
+  

--- a/tasks/checks.yml
+++ b/tasks/checks.yml
@@ -3,4 +3,3 @@
   fail:
     msg: 'You can set solr_jetty_host other than 127.0.0.1 only when the Solr version is 9.3.0 or higher'
   when: solr_jetty_host != '127.0.0.1' and solr_version is version('9.3.0' ,'<')
-  

--- a/tasks/checks.yml
+++ b/tasks/checks.yml
@@ -1,0 +1,4 @@
+- name: Check for incompatible solr_jetty_host
+  fail:
+    msg: 'You can set solr_jetty_host other than 127.0.0.1 only when the Solr version is 9.3.0 or higher'
+  when: solr_jetty_host != '127.0.0.1' and solr_version is version('9.3.0' ,'<')

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -51,4 +51,3 @@
     name: solr
     state: restarted
   when: solr_config.changed
-  

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -23,3 +23,31 @@
     - regexp: "^.?SOLR_OPTS="
       line: 'SOLR_OPTS="{{ solr_opts }}"'
   notify: restart solr
+  when: solr_jetty_host == '127.0.0.1'
+
+- name: Apply Solr configuration changes solr >= 9.3.0.
+  lineinfile:
+    dest: "{{ solr_config_file }}"
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+    state: present
+    mode: 0644
+  with_items:
+    - regexp: "^.?SOLR_JAVA_MEM="
+      line: 'SOLR_JAVA_MEM="-Xms{{ solr_xms }} -Xmx{{ solr_xmx }}"'
+    - regexp: "^SOLR_PORT="
+      line: 'SOLR_PORT="{{ solr_port }}"'
+    - regexp: "^.?SOLR_TIMEZONE="
+      line: 'SOLR_TIMEZONE="{{ solr_timezone }}"'
+    - regexp: "^.?SOLR_OPTS="
+      line: 'SOLR_OPTS="{{ solr_opts }}"'
+    - regexp: "^.?SOLR_JETTY_HOST="
+      line: 'SOLR_JETTY_HOST="{{ solr_jetty_host }}"'
+  register: solr_config
+  when: solr_jetty_host != '127.0.0.1'
+
+- name: Restart solr to load new configuration
+  service:
+    name: solr
+    state: restarted
+  when: solr_config.changed

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -51,3 +51,4 @@
     name: solr
     state: restarted
   when: solr_config.changed
+  

--- a/tasks/cores-post93.yml
+++ b/tasks/cores-post93.yml
@@ -1,0 +1,32 @@
+---
+- name: Check current list of Solr cores.
+  uri:
+    url: http://{{ solr_jetty_host }}:{{ solr_port }}/solr/admin/cores
+    return_content: true
+  register: solr_cores_current
+  check_mode: false
+
+- name: Ensure Solr conf directories exist.
+  file:
+    path: "{{ solr_home }}/data/{{ item }}/conf"
+    state: directory
+    owner: "{{ solr_user }}"
+    group: "{{ solr_group }}"
+    recurse: true
+    mode: 0755
+  when: "item not in solr_cores_current.content"
+  with_items: "{{ solr_cores }}"
+
+- name: Ensure core configuration directories exist.
+  command: "cp -r {{ solr_default_core_path }} {{ solr_home }}/data/{{ item }}/"
+  when: "item not in solr_cores_current.content"
+  with_items: "{{ solr_cores }}"
+  become: true
+  become_user: "{{ solr_user }}"
+
+- name: Create configured cores.
+  command: "{{ solr_install_path }}/bin/solr create -c {{ item }} -h {{ solr_jetty_host }} -p {{ solr_port }}"
+  when: "item not in solr_cores_current.content"
+  with_items: "{{ solr_cores }}"
+  become: true
+  become_user: "{{ solr_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- import_tasks: checks.yml
+
 - import_tasks: user.yml
   when: solr_create_user
 
@@ -64,6 +66,17 @@
 
 # Create cores, if any are configured.
 - include_tasks: cores.yml
-  when: "solr_cores and solr_version.split('.')[0] >= '5'"
+  when: 
+    - solr_cores 
+    - solr_version.split('.')[0] >= '5'
+    - solr_jetty_host == '127.0.0.1'
+
+# Create cores also when solr is listening on custom network interface. Just for solr 9.3.0 and higher.
+- include_tasks: cores-post93.yml
+  when: 
+    - solr_cores 
+    - solr_version is version('9.3.0' ,'>=')
+    - solr_jetty_host != '127.0.0.1'
+
 
 - include_tasks: trim-fat.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,15 +66,15 @@
 
 # Create cores, if any are configured.
 - include_tasks: cores.yml
-  when: 
-    - solr_cores 
+  when:
+    - solr_cores
     - solr_version.split('.')[0] >= '5'
     - solr_jetty_host == '127.0.0.1'
 
 # Create cores also when solr is listening on custom network interface. Just for solr 9.3.0 and higher.
 - include_tasks: cores-post93.yml
-  when: 
-    - solr_cores 
+  when:
+    - solr_cores
     - solr_version is version('9.3.0' ,'>=')
     - solr_jetty_host != '127.0.0.1'
 


### PR DESCRIPTION
- Added the possibility to define a network interface on which solr will listen using the variable `solr_jetty_host`.
- Solr version 9.3.0 and higher introduced the `-h` host parameter in solr create script.
- I kept backward compatibility for people already using this role, according to my tests.