### PR TITLE
Fix non boolean conditional for ansible 2.19

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,6 +64,6 @@
 
 # Create cores, if any are configured.
 - include_tasks: cores.yml
-  when: "solr_cores and solr_version.split('.')[0] >= '5'"
+  when: "solr_cores is defined and solr_version.split('.')[0] >= '5'"
 
 - include_tasks: trim-fat.yml


### PR DESCRIPTION
Ansible 2.19 error message:

```
Conditional result (False) was derived from value of type 'list' at 'ansible/sandbox/host_vars/solr.yml:9:13'. Conditionals must have a boolean result.
Origin: roles/geerlingguy.solr/tasks/main.yml:67:9

65 # Create cores, if any are configured.
66 - include_tasks: cores.yml
67   when: "solr_cores and solr_version.split('.')[0] >= '5'"
           ^ column 9
```